### PR TITLE
chore: move map components up a layer

### DIFF
--- a/src/components/Map/VectorTileLayers/index.tsx
+++ b/src/components/Map/VectorTileLayers/index.tsx
@@ -1,1 +1,0 @@
-export * from './PolygonLayer'

--- a/src/components/MapFilledPolygonLayer/index.tsx
+++ b/src/components/MapFilledPolygonLayer/index.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react'
 import { Source, Layer, LayerProps } from 'react-map-gl'
-export interface PolygonLayerType {
+export interface MapFilledPolygonLayerType {
   id: string
   tileset: {
     url: string
@@ -10,7 +10,7 @@ export interface PolygonLayerType {
   fillColorProperty: string
 }
 
-export const PolygonLayer: FC<PolygonLayerType> = ({
+export const MapFilledPolygonLayer: FC<MapFilledPolygonLayerType> = ({
   id,
   tileset,
   fillColorMap,

--- a/src/modules/RefreshmentMap/content.ts
+++ b/src/modules/RefreshmentMap/content.ts
@@ -1,4 +1,4 @@
-import { PolygonLayerType } from '../../components/Map/VectorTileLayers'
+import { MapFilledPolygonLayerType } from '../../components/MapFilledPolygonLayer'
 
 export const HOURS = [
   {
@@ -54,7 +54,7 @@ export const HOURS = [
 export type QuantileValues = 1 | 2 | 3 | 4 | 5
 
 export const WIND_DATA: Pick<
-  PolygonLayerType,
+  MapFilledPolygonLayerType,
   'id' | 'tileset' | 'fillColorMap'
 > = {
   id: 'wind-data',
@@ -73,7 +73,7 @@ export const WIND_DATA: Pick<
 }
 
 export const TEMPERATURE_DATA: Pick<
-  PolygonLayerType,
+  MapFilledPolygonLayerType,
   'id' | 'tileset' | 'fillColorMap'
 > = {
   id: 'temperature-data',

--- a/src/modules/RefreshmentMap/index.tsx
+++ b/src/modules/RefreshmentMap/index.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react'
 import { FullScreenMapWrapper } from '../../layouts/FullScreenMapWrapper'
 import { Map as MapRoot } from '../../components/Map'
-import { PolygonLayer } from '../../components/Map/VectorTileLayers'
+import { MapFilledPolygonLayer as FilledPolygonLayer } from '../../components/MapFilledPolygonLayer'
 import { useWindowSize } from '../../lib/hooks/useWindowSize'
 import { HOURS, TEMPERATURE_DATA, WIND_DATA } from './content'
 
@@ -46,8 +46,11 @@ export const RefreshmentMap: FC = () => {
         longitude={13.400033}
         zoom={13}
       >
-        <PolygonLayer {...WIND_DATA} fillColorProperty={activeHour} />
-        <PolygonLayer {...TEMPERATURE_DATA} fillColorProperty={activeHour} />
+        <FilledPolygonLayer {...WIND_DATA} fillColorProperty={activeHour} />
+        <FilledPolygonLayer
+          {...TEMPERATURE_DATA}
+          fillColorProperty={activeHour}
+        />
       </MapRoot>
     </FullScreenMapWrapper>
   )


### PR DESCRIPTION
This PR moves the map related components up a level. Now it is on the same level as the `Map` component itself.