### PR TITLE
feat(ERF-59): add possibility to filter Points/POIs

### DIFF
--- a/src/components/MapPointLayer/index.tsx
+++ b/src/components/MapPointLayer/index.tsx
@@ -9,6 +9,7 @@ export interface MapPointLayerType extends Omit<LayerProps, 'type' | 'paint'> {
   }
   fillColorMap: Map<number | string, string>
   fillColorProperty: string
+  activePropertyKeys?: string[]
 }
 
 type ZoomThresholds = 12 | 15 | 18
@@ -33,10 +34,26 @@ export const MapPointLayer: FC<MapPointLayerType> = ({
   minzoom,
   fillColorMap,
   fillColorProperty,
+  activePropertyKeys,
 }) => {
   const flattenedFillColorMap = Array.from(fillColorMap).flat(2)
   const flattenedCircleRadiusMap = Array.from(CircleRadiusMap).flat(2)
   const flattenedCircleStrokeWidthMap = Array.from(CircleStrokeWidthMap).flat(2)
+
+  const filterDataIsProvided =
+    !!activePropertyKeys && activePropertyKeys.length > 0
+
+  const filteringExpression = [
+    'in',
+    ['get', `${fillColorProperty}`],
+    ['literal', activePropertyKeys],
+  ]
+
+  const nonFilteringExpression = ['has', `${fillColorProperty}`]
+
+  const filter = filterDataIsProvided
+    ? filteringExpression
+    : nonFilteringExpression
 
   const layerStyle: LayerProps = {
     id: id,
@@ -69,7 +86,7 @@ export const MapPointLayer: FC<MapPointLayerType> = ({
 
   return (
     <Source id={id} type="vector" url={tileset.url}>
-      <Layer {...layerStyle} />
+      <Layer {...layerStyle} filter={filter} />
     </Source>
   )
 }

--- a/src/modules/RefreshmentMap/content.ts
+++ b/src/modules/RefreshmentMap/content.ts
@@ -131,6 +131,7 @@ type PoiCategory =
 
 export interface PoiDataType extends MapPointLayerType {
   fillColorMap: Map<PoiCategory, string>
+  activePropertyKeys: Partial<PoiCategory>[]
 }
 
 export const POI_DATA: PoiDataType = {
@@ -153,4 +154,15 @@ export const POI_DATA: PoiDataType = {
     ['Sitzbank', '#C37D3C'],
     ['Picknicktisch', '#C37D3C'],
   ]),
+  activePropertyKeys: [
+    'Picknicktisch',
+    'Gruenanlage',
+    'Trinkbrunnen',
+    'Brunnen',
+    'Wasserspielplatz',
+    'Badestelle',
+    'Strandbad',
+    'Freibad',
+    'Schwimmhalle',
+  ],
 }


### PR DESCRIPTION
This PR implements filtering for the `MapPointLayer`:

If `activePropertyKeys` are provided, only the Point features included in that array will be rendered. If no array or an empty array is provided, all Point features will be rendered by default.

This can later be used for updating the visible POIs from the sidebar. For now an exemplary default selection was created (that excludes Sitzbänke)