### PR TITLE
webp support hook

### DIFF
--- a/src/lib/hooks/useHasWebPSupport/index.ts
+++ b/src/lib/hooks/useHasWebPSupport/index.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+export const useHasWebPSupport = (): boolean => {
+  const [supported, setSupported] = useState(false)
+
+  const kTestImages = {
+    lossy: 'UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA',
+    lossless: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==',
+    alpha:
+      'UklGRkoAAABXRUJQVlA4WAoAAAAQAAAAAAAAAAAAQUxQSAwAAAARBxAR/Q9ERP8DAABWUDggGAAAABQBAJ0BKgEAAQAAAP4AAA3AAP7mtQAAAA==',
+    animation:
+      'UklGRlIAAABXRUJQVlA4WAoAAAASAAAAAAAAAAAAQU5JTQYAAAD/////AABBTk1GJgAAAAAAAAAAAAAAAAAAAGQAAABWUDhMDQAAAC8AAAAQBxAREYiI/gcA',
+  }
+
+  if (typeof window !== 'undefined') {
+    const img = new Image()
+
+    img.onload = () => setSupported(img.width > 0 && img.height > 0)
+    img.onerror = () => setSupported(false)
+
+    img.src = 'data:image/webp;base64,' + kTestImages['alpha']
+  }
+
+  return supported
+}

--- a/src/lib/hooks/useHasWebPSupport/useHasWebPSupport.test.tsx
+++ b/src/lib/hooks/useHasWebPSupport/useHasWebPSupport.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import { FC, useEffect } from 'react'
+import { useHasWebPSupport } from '.'
+
+type OnSuccessType = (hasWebPSupport: boolean) => void
+
+const createTestComponent = (onSuccess: OnSuccessType): FC => {
+  const TestComponent: FC = () => {
+    const hasWebPSupport = useHasWebPSupport()
+    useEffect(() => {
+      onSuccess(hasWebPSupport)
+    }, [hasWebPSupport])
+
+    return <div />
+  }
+  return TestComponent
+}
+describe('useHasWebPSupport', () => {
+  //jest virtual browser doesn't support webp
+  test('should default to false with jest', () => {
+    const onSuccess = jest.fn()
+    const TestComponent = createTestComponent(onSuccess)
+    render(<TestComponent />)
+
+    expect(onSuccess).toHaveBeenLastCalledWith(false)
+  })
+})

--- a/src/modules/RefreshmentMap/index.tsx
+++ b/src/modules/RefreshmentMap/index.tsx
@@ -26,6 +26,7 @@ import {
 } from '@components/MapPoiTooltip'
 import { MapEvent } from 'react-map-gl'
 import { mapRawQueryToState } from '@lib/utils/queryUtil'
+import { useHasWebPSupport } from '@lib/hooks/useHasWebPSupport'
 
 interface RefreshmentMapPropType {
   title?: string
@@ -46,6 +47,7 @@ interface CustomMapEventType extends MapEvent {
 
 export const RefreshmentMap: FC<RefreshmentMapPropType> = (pageProps) => {
   const hasMobileSize = useHasMobileSize()
+  const hasWebPSupport = useHasWebPSupport()
   const { width: windowWidth, height: windowHeight } = useWindowSize()
 
   const { pathname, query, replace: routerReplace } = useRouter()
@@ -135,9 +137,21 @@ export const RefreshmentMap: FC<RefreshmentMapPropType> = (pageProps) => {
           {...TEMPERATURE_DATA}
           fillColorProperty={activeHour.vectorTilesetKey}
         />
-        {hourKeys.map((key) => {
-          const item = HOURS[key]
-          if (key !== activeHourKey) {
+        {hasWebPSupport &&
+          hourKeys.map((key) => {
+            const item = HOURS[key]
+            if (key !== activeHourKey) {
+              return (
+                <RasterLayer
+                  key={`shade-${key}`}
+                  id={`shade-${key}`}
+                  url={item.shadeTilesetId}
+                  bounds={[13.06, 52.33, 13.77, 52.69]}
+                  minZoom={14}
+                  opacity={0}
+                />
+              )
+            }
             return (
               <RasterLayer
                 key={`shade-${key}`}
@@ -145,21 +159,10 @@ export const RefreshmentMap: FC<RefreshmentMapPropType> = (pageProps) => {
                 url={item.shadeTilesetId}
                 bounds={[13.06, 52.33, 13.77, 52.69]}
                 minZoom={14}
-                opacity={0}
+                opacity={0.5}
               />
             )
-          }
-          return (
-            <RasterLayer
-              key={`shade-${key}`}
-              id={`shade-${key}`}
-              url={item.shadeTilesetId}
-              bounds={[13.06, 52.33, 13.77, 52.69]}
-              minZoom={14}
-              opacity={0.5}
-            />
-          )
-        })}
+          })}
         <ExtrusionLayer {...EXTRUDED_BUILDINGS_DATA} />
         <MapPointLayer {...POI_DATA} />
         {poiTooltipCoordinates &&


### PR DESCRIPTION
In this PR I have created a hook if webp is supported or not and the map module doesn't display the rasterlayer if webp is not supported. @dnsos maybe the best place to implement the warning message would be in the filter sidebar around the shadow option. What do you think?