### PR TITLE
chore: benches visible by default

### DIFF
--- a/src/components/MapPoiTooltip/MapPoiTooltip.stories.tsx
+++ b/src/components/MapPoiTooltip/MapPoiTooltip.stories.tsx
@@ -1,7 +1,9 @@
 import { Story, Meta } from '@storybook/react'
+import { withNextRouter } from 'storybook-addon-next-router'
 import { Map } from '@components/Map'
+import '../MapPoiTooltip/MapPoiTooltip.css'
 
-import { MapPoiTooltip } from '.'
+import { MapPoiTooltip, MapPoiTooltipType } from '.'
 
 const initialViewportProps = {
   latitude: 52.520952,
@@ -12,9 +14,10 @@ const initialViewportProps = {
 export default {
   title: 'UI Elements/MapPoiTooltip',
   component: MapPoiTooltip,
+  decorators: [withNextRouter],
 } as Meta
 
-const Template: Story = (args) => {
+const Template: Story<MapPoiTooltipType> = (args) => {
   return (
     <Map
       width={800}
@@ -22,20 +25,29 @@ const Template: Story = (args) => {
       initialViewportProps={initialViewportProps}
       mapStyle="mapbox://styles/mapbox/light-v10"
     >
-      <MapPoiTooltip
-        coordinates={{ latitude: 52.520952, longitude: 13.400033 }}
-        title="Tooltip for a park"
-        category="Park"
-        {...args}
-      />
+      <MapPoiTooltip {...args} />
     </Map>
   )
 }
 
 export const Default = Template.bind({})
-Default.args = {}
+Default.args = {
+  coordinates: { latitude: 52.520952, longitude: 13.400033 },
+  title: 'Tooltip for a park',
+  category: 'Park',
+}
 
 export const WithInfo = Template.bind({})
 WithInfo.args = {
+  coordinates: { latitude: 52.520952, longitude: 13.400033 },
+  title: 'Tooltip for a park',
+  category: 'Park',
   info: 'Lots of trees here, some fountains as well',
+}
+
+export const WithIdenticalTitleAndCategory = Template.bind({})
+WithIdenticalTitleAndCategory.args = {
+  coordinates: { latitude: 52.520952, longitude: 13.400033 },
+  title: 'Park',
+  category: 'PARK',
 }

--- a/src/components/MapPoiTooltip/index.tsx
+++ b/src/components/MapPoiTooltip/index.tsx
@@ -25,7 +25,10 @@ export const MapPoiTooltip: FC<MapPoiTooltipType> = ({
       className="w-64"
     >
       <h4 className="text-xl leading-6 text-gray-900">{title}</h4>
-      <p className="text-gray-400">{category}</p>
+      {category.toLowerCase() !== title.toLowerCase() && (
+        <p className="text-gray-400">{category}</p>
+      )}
+
       {info && (
         <p className="text-xs text-gray-900 pt-2 mt-2 border-t">{info}</p>
       )}

--- a/src/modules/RefreshmentMap/content.tsx
+++ b/src/modules/RefreshmentMap/content.tsx
@@ -197,6 +197,7 @@ export const POI_DATA: PoiDataType = {
     ['Picknicktisch', colors['poi-red']],
   ]),
   activePropertyKeys: [
+    'Sitzbank',
     'Picknicktisch',
     'Gruenanlage',
     'Trinkbrunnen',

--- a/test/components/MapPoiTooltip/__snapshots__/MapPoiTooltip.stories.storyshot
+++ b/test/components/MapPoiTooltip/__snapshots__/MapPoiTooltip.stories.storyshot
@@ -36,6 +36,42 @@ exports[`Storyshots UI Elements/MapPoiTooltip Default 1`] = `
 </div>
 `;
 
+exports[`Storyshots UI Elements/MapPoiTooltip With Identical Title And Category 1`] = `
+<div
+  style={
+    Object {
+      "cursor": "grab",
+      "height": 500,
+      "position": "relative",
+      "width": 800,
+    }
+  }
+>
+  <div
+    style={
+      Object {
+        "height": "100%",
+        "position": "relative",
+        "width": "100%",
+      }
+    }
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "height": "100%",
+          "overflow": "hidden",
+          "position": "absolute",
+          "visibility": "inherit",
+          "width": "100%",
+        }
+      }
+    />
+  </div>
+</div>
+`;
+
 exports[`Storyshots UI Elements/MapPoiTooltip With Info 1`] = `
 <div
   style={


### PR DESCRIPTION
This PR makes the benches visible by default. We had decided that generally we want to disable them at first. However, as long as there is no way to enable them without the functionality of the filters, we should have them visible by default, at least for now.

I'm also thinking that perhaps this should be the case anyway, since we have POI suggestions of benches. When selecting one of them, we are brought to the location and no bench is visible  😢 