### PR TITLE
feat(ERF-60): sync filters and query params

### DIFF
--- a/pages/filters.tsx
+++ b/pages/filters.tsx
@@ -107,6 +107,7 @@ export const Filters: FC<{
                 )
               }
               layerIsActive={mappedQuery.showShadows !== false}
+              layerIsDisabled={!hasWebPSupport}
               handleToggle={() => {
                 void routerReplace(
                   {

--- a/pages/filters.tsx
+++ b/pages/filters.tsx
@@ -14,6 +14,7 @@ import { useHasWebPSupport } from '@lib/hooks/useHasWebPSupport'
 import classNames from 'classnames'
 import { LayerLegendBlock } from '@components/LayerLegendBlock'
 import { Warning } from '@components/Warning'
+import { useRouter } from 'next/router'
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export const getServerSideProps: GetServerSideProps = async ({ query }) => ({
@@ -30,6 +31,8 @@ export const Filters: FC<{
 }> = () => {
   const hasMobileSize = useHasMobileSize()
   const hasWebPSupport = useHasWebPSupport()
+  const { query, replace: routerReplace } = useRouter()
+  const mappedQuery = mapRawQueryToState(query)
 
   const {
     shade: shadeLegendContent,
@@ -103,7 +106,22 @@ export const Filters: FC<{
                   <Warning>{SHADE_SUPPORT_NOTE}</Warning>
                 )
               }
-              handleToggle={() => console.log('clicked')}
+              layerIsActive={mappedQuery.showShadows !== false}
+              handleToggle={() => {
+                void routerReplace(
+                  {
+                    query: {
+                      ...mappedQuery,
+                      showShadows: Object.keys(mappedQuery).includes(
+                        'showShadows'
+                      )
+                        ? !mappedQuery.showShadows
+                        : false,
+                    },
+                  },
+                  undefined
+                )
+              }}
             />
           </div>
         )}
@@ -114,7 +132,22 @@ export const Filters: FC<{
               description={temperatureLegendContent.description}
               icon={temperatureLegendContent.icon}
               legendFigure={temperatureLegendContent.legendFigure}
-              handleToggle={() => console.log('clicked')}
+              layerIsActive={mappedQuery.showTemperature !== false}
+              handleToggle={() => {
+                void routerReplace(
+                  {
+                    query: {
+                      ...mappedQuery,
+                      showTemperature: Object.keys(mappedQuery).includes(
+                        'showTemperature'
+                      )
+                        ? !mappedQuery.showTemperature
+                        : false,
+                    },
+                  },
+                  undefined
+                )
+              }}
             />
           </div>
         )}
@@ -125,7 +158,20 @@ export const Filters: FC<{
               description={windLegendContent.description}
               icon={windLegendContent.icon}
               legendFigure={windLegendContent.legendFigure}
-              handleToggle={() => console.log('clicked')}
+              layerIsActive={mappedQuery.showWind !== false}
+              handleToggle={() => {
+                void routerReplace(
+                  {
+                    query: {
+                      ...mappedQuery,
+                      showWind: Object.keys(mappedQuery).includes('showWind')
+                        ? !mappedQuery.showWind
+                        : false,
+                    },
+                  },
+                  undefined
+                )
+              }}
             />
           </div>
         )}

--- a/pages/filters.tsx
+++ b/pages/filters.tsx
@@ -175,6 +175,23 @@ export const Filters: FC<{
             />
           </div>
         )}
+        {mappedQuery.showWind && mappedQuery.showTemperature && (
+          <p
+            className={classNames(
+              'text-xs',
+              'mt-4',
+              hasMobileSize ? 'ml-10' : null
+            )}
+          >
+            <strong className="italic text-layer-turquoise-300">
+              Aufgepasst:
+            </strong>
+            {` `}
+            {`Gleichzeitig kühle und windige Flächen werden ${
+              !hasMobileSize ? 'durch die Überlagerung von Blau und Grün' : ''
+            } Türkis dargestellt.`}
+          </p>
+        )}
       </section>
     </div>
   )

--- a/src/components/FilterChip/FilterChip.test.tsx
+++ b/src/components/FilterChip/FilterChip.test.tsx
@@ -17,6 +17,7 @@ describe('FilterChip', () => {
 
     const button = screen.getByRole('button')
     expect(button.getAttribute('class')?.includes('border-gray-400')).toBe(true)
+    expect(button.getAttribute('class')?.includes('opacity-100')).toBe(true)
   })
 
   it('has deselected styles if deselected', () => {
@@ -28,5 +29,6 @@ describe('FilterChip', () => {
 
     const button = screen.getByRole('button')
     expect(button.getAttribute('class')?.includes('border-gray-200')).toBe(true)
+    expect(button.getAttribute('class')?.includes('opacity-50')).toBe(true)
   })
 })

--- a/src/components/FilterChip/FilterChip.test.tsx
+++ b/src/components/FilterChip/FilterChip.test.tsx
@@ -16,7 +16,6 @@ describe('FilterChip', () => {
     render(<FilterChip ariaLabel="aria label content">I am visible</FilterChip>)
 
     const button = screen.getByRole('button')
-    expect(button.getAttribute('class')?.includes('border-gray-400')).toBe(true)
     expect(button.getAttribute('class')?.includes('opacity-100')).toBe(true)
   })
 
@@ -28,7 +27,17 @@ describe('FilterChip', () => {
     )
 
     const button = screen.getByRole('button')
-    expect(button.getAttribute('class')?.includes('border-gray-200')).toBe(true)
     expect(button.getAttribute('class')?.includes('opacity-50')).toBe(true)
+  })
+
+  it('has disbled styles if disabled', () => {
+    render(
+      <FilterChip ariaLabel="aria label content" isDisabled={true}>
+        I am visible
+      </FilterChip>
+    )
+
+    const button = screen.getByRole('button')
+    expect(button.getAttribute('class')?.includes('border-gray-200')).toBe(true)
   })
 })

--- a/src/components/FilterChip/index.tsx
+++ b/src/components/FilterChip/index.tsx
@@ -26,7 +26,9 @@ export const FilterChip: FC<FilterChipType> = ({
         otherClassNames,
         isSelected
           ? 'border-gray-400 text-gray-900'
-          : 'border-gray-200 text-gray-500'
+          : 'border-gray-200 text-gray-500',
+        'transition-opacity duration-75 ease-in-out',
+        isSelected ? 'opacity-100' : 'opacity-50'
       )}
       aria-label={ariaLabel}
       onClick={handleClick}

--- a/src/components/FilterChip/index.tsx
+++ b/src/components/FilterChip/index.tsx
@@ -6,6 +6,7 @@ export interface FilterChipType extends HTMLAttributes<HTMLButtonElement> {
   isSelected?: boolean
   otherClassNames?: string
   handleClick?: () => void
+  isDisabled?: boolean
 }
 
 export const FilterChip: FC<FilterChipType> = ({
@@ -13,6 +14,7 @@ export const FilterChip: FC<FilterChipType> = ({
   isSelected = true,
   otherClassNames,
   handleClick = console.log,
+  isDisabled,
   children,
   ...otherButtonProps
 }) => {
@@ -24,14 +26,15 @@ export const FilterChip: FC<FilterChipType> = ({
         'focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none',
         'focus:ring-offset-2 focus:ring-offset-white',
         otherClassNames,
-        isSelected
-          ? 'border-gray-400 text-gray-900'
-          : 'border-gray-200 text-gray-500',
+        isSelected ? 'border-gray-40' : 'border-gray-200',
         'transition-opacity duration-75 ease-in-out',
-        isSelected ? 'opacity-100' : 'opacity-50'
+        isSelected ? 'opacity-100' : 'opacity-50',
+        'disabled:opacity-100 disabled:cursor-not-allowed',
+        isDisabled ? 'border-gray-200' : null
       )}
       aria-label={ariaLabel}
       onClick={handleClick}
+      disabled={isDisabled}
       {...otherButtonProps}
     >
       {children}

--- a/src/components/InternalLink/index.tsx
+++ b/src/components/InternalLink/index.tsx
@@ -8,15 +8,6 @@ interface InternalLinkPropType extends LinkProps {
   className?: string
 }
 
-const serialize = (obj: Record<string, unknown>): string => {
-  const str = []
-  for (const p in obj)
-    if (Object.prototype.hasOwnProperty.call(obj, p)) {
-      str.push(encodeURIComponent(p) + '=' + encodeURIComponent(String(obj[p])))
-    }
-  return str.join('&')
-}
-
 export const InternalLink: FC<InternalLinkPropType> = ({
   href,
   children,
@@ -24,14 +15,13 @@ export const InternalLink: FC<InternalLinkPropType> = ({
   ...rest
 }) => {
   const { query } = useRouter()
-  const cleanedQuery = mapRawQueryToState(query)
-  const queryAsString = serialize(cleanedQuery)
+  const mappedQuery = mapRawQueryToState(query)
 
   return (
     <Link
       href={{
         pathname: href,
-        query: queryAsString,
+        query: mappedQuery,
       }}
       {...rest}
     >

--- a/src/components/LayerLegendBlock/index.tsx
+++ b/src/components/LayerLegendBlock/index.tsx
@@ -10,6 +10,7 @@ export interface LayerLegendBlockType {
   icon: ReactNode
   legendFigure: ReactNode | HTMLElement
   layerIsActive?: boolean
+  layerIsDisabled?: boolean
   handleToggle: () => void
 }
 
@@ -19,6 +20,7 @@ export const LayerLegendBlock: FC<LayerLegendBlockType> = ({
   icon,
   legendFigure,
   layerIsActive = true,
+  layerIsDisabled = false,
   handleToggle,
 }) => {
   const hasMobileSize = useHasMobileSize()
@@ -56,6 +58,7 @@ export const LayerLegendBlock: FC<LayerLegendBlockType> = ({
             ariaLabel={`${title} an oder auswählen`}
             otherClassNames="w-full"
             isSelected={layerIsActive}
+            isDisabled={layerIsDisabled}
             handleClick={handleToggle}
           >
             {legendFigure}

--- a/src/components/LayerLegendBlock/index.tsx
+++ b/src/components/LayerLegendBlock/index.tsx
@@ -9,6 +9,7 @@ export interface LayerLegendBlockType {
   description: string
   icon: ReactNode
   legendFigure: ReactNode | HTMLElement
+  layerIsActive?: boolean
   handleToggle: () => void
 }
 
@@ -17,6 +18,7 @@ export const LayerLegendBlock: FC<LayerLegendBlockType> = ({
   description,
   icon,
   legendFigure,
+  layerIsActive = true,
   handleToggle,
 }) => {
   const hasMobileSize = useHasMobileSize()
@@ -53,6 +55,7 @@ export const LayerLegendBlock: FC<LayerLegendBlockType> = ({
           <FilterChip
             ariaLabel={`${title} an oder auswählen`}
             otherClassNames="w-full"
+            isSelected={layerIsActive}
             handleClick={handleToggle}
           >
             {legendFigure}

--- a/src/components/MapPointLayer/index.tsx
+++ b/src/components/MapPointLayer/index.tsx
@@ -40,8 +40,7 @@ export const MapPointLayer: FC<MapPointLayerType> = ({
   const flattenedCircleRadiusMap = Array.from(CircleRadiusMap).flat(2)
   const flattenedCircleStrokeWidthMap = Array.from(CircleStrokeWidthMap).flat(2)
 
-  const filterDataIsProvided =
-    !!activePropertyKeys && activePropertyKeys.length > 0
+  const filterDataIsProvided = !!activePropertyKeys
 
   const filteringExpression = [
     'in',

--- a/src/components/Warning/index.tsx
+++ b/src/components/Warning/index.tsx
@@ -5,17 +5,13 @@ import { FC } from 'react'
 export const Warning: FC = ({ children, ...otherWarningProps }) => {
   return (
     <div
-      className={classNames(
-        'flex',
-        'max-w-prose p-3',
-        'border border-[#ff7300] border-opacity-40 rounded'
-      )}
+      className={classNames('flex', 'max-w-prose p-3')}
       {...otherWarningProps}
     >
       <div className="flex-grow-0 text-[#ff7300]">
         <ExclamationIcon />
       </div>
-      <div className="ml-2">{children}</div>
+      <div className="ml-2 text-left">{children}</div>
     </div>
   )
 }

--- a/src/lib/utils/queryUtil/index.ts
+++ b/src/lib/utils/queryUtil/index.ts
@@ -25,15 +25,17 @@ const parseSingleNumber = (
 }
 
 const parseNumbersArray = (
-  val: string | string[] | undefined
+  val: string | string[] | false | undefined
 ): number[] | null => {
-  if (!val) return null
+  if (typeof val === 'undefined') return null
   if (Array.isArray(val)) {
     return val.map(parseSingleNumber).filter(Boolean) as number[]
   }
+  if (val === 'false') return []
   if (typeof val !== 'string') return null
   try {
     const parsedJson = JSON.parse(val) as unknown
+    if (isNumber(parsedJson)) [parsedJson] as number[]
     if (!Array.isArray(parsedJson)) return null
     return parsedJson.map(parseSingleNumber).filter(Boolean) as number[]
   } catch (err) {

--- a/src/modules/RefreshmentMap/content.tsx
+++ b/src/modules/RefreshmentMap/content.tsx
@@ -616,7 +616,7 @@ export const LAYER_LEGEND_ITEMS: {
 }
 
 export const SHADE_SUPPORT_NOTE = (
-  <p className="text-sm">
+  <p className="text-xs">
     Leider können die Schatten auf diesem Endgerät oder in diesem Browser nicht
     dargestellt werden. Bitte versuche ein anderes Endgerät oder einen anderen
     Browser, um die Karte zu öffnen.

--- a/src/modules/RefreshmentMap/content.tsx
+++ b/src/modules/RefreshmentMap/content.tsx
@@ -175,7 +175,7 @@ export type PoiCategory =
   | 'Freibad'
   | 'Schwimmhalle'
 
-export const POI_CATEGORIES: Map<PoiCategory, string> = new Map([
+export const POI_CATEGORY_COLOR_MAP: Map<PoiCategory, string> = new Map([
   ['Badestelle', colors['poi-darkblue']],
   ['Strandbad', colors['poi-darkblue']],
   ['Freibad', colors['poi-darkblue']],
@@ -187,6 +187,19 @@ export const POI_CATEGORIES: Map<PoiCategory, string> = new Map([
   ['Sitzbank', colors['poi-yellow']],
   ['Picknicktisch', colors['poi-red']],
 ])
+
+export const POI_CATEGORY_ID_MAP: { [key in PoiCategory]: number } = {
+  Badestelle: 1,
+  Strandbad: 2,
+  Freibad: 3,
+  Schwimmhalle: 4,
+  Wasserspielplatz: 5,
+  Trinkbrunnen: 6,
+  Brunnen: 7,
+  Gruenanlage: 8,
+  Sitzbank: 9,
+  Picknicktisch: 10,
+}
 
 export interface PoiDataType extends MapPointLayerType {
   id: string
@@ -202,18 +215,18 @@ export const POI_DATA: PoiDataType = {
   },
   minzoom: 11.5,
   fillColorProperty: 'category',
-  fillColorMap: POI_CATEGORIES,
+  fillColorMap: POI_CATEGORY_COLOR_MAP,
   activePropertyKeys: [
-    'Sitzbank',
-    'Picknicktisch',
-    'Gruenanlage',
-    'Trinkbrunnen',
-    'Brunnen',
-    'Wasserspielplatz',
     'Badestelle',
     'Strandbad',
     'Freibad',
     'Schwimmhalle',
+    'Wasserspielplatz',
+    'Trinkbrunnen',
+    'Brunnen',
+    'Gruenanlage',
+    'Sitzbank',
+    'Picknicktisch',
   ],
 }
 

--- a/src/modules/RefreshmentMap/index.tsx
+++ b/src/modules/RefreshmentMap/index.tsx
@@ -12,6 +12,7 @@ import {
   WIND_DATA,
   POI_DATA,
   HourType,
+  POI_CATEGORY_ID_MAP,
 } from './content'
 import { MapRasterLayer as RasterLayer } from '../../components/MapRasterLayer'
 import { MapExtrusionLayer as ExtrusionLayer } from '../../components/MapExtrusionLayer'
@@ -102,6 +103,15 @@ export const RefreshmentMap: FC<RefreshmentMapPropType> = (pageProps) => {
     poiTooltipContent.title !== '' &&
     poiTooltipContent.category !== ''
 
+  const activeCategories = mappedQuery.places
+    ?.map(
+      (poiId) =>
+        Object.entries(POI_CATEGORY_ID_MAP).find(
+          ([, id]) => id === poiId
+        )?.[0] || ''
+    )
+    .filter(Boolean)
+
   return (
     <>
       {pathname === '/map' && <AppTitle />}
@@ -158,12 +168,7 @@ export const RefreshmentMap: FC<RefreshmentMapPropType> = (pageProps) => {
             />
           ))}
         <ExtrusionLayer {...EXTRUDED_BUILDINGS_DATA} />
-        <MapPointLayer
-          {...POI_DATA}
-          activePropertyKeys={mappedQuery.places
-            ?.map((idx) => POI_DATA.activePropertyKeys[idx])
-            .filter(Boolean)}
-        />
+        <MapPointLayer {...POI_DATA} activePropertyKeys={activeCategories} />
         {poiTooltipCoordinates &&
           poiTooltipContent &&
           poiTooltipContentIsNotEmpty && (

--- a/test/components/FilterChip/__snapshots__/FilterChip.stories.storyshot
+++ b/test/components/FilterChip/__snapshots__/FilterChip.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots UI Elements/FilterChip Default 1`] = `
 <button
   aria-label="I am an aria label"
-  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-400 text-gray-900"
+  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-400 text-gray-900 transition-opacity duration-75 ease-in-out opacity-100"
   onClick={[Function]}
   type="button"
 >
@@ -16,7 +16,7 @@ exports[`Storyshots UI Elements/FilterChip Default 1`] = `
 exports[`Storyshots UI Elements/FilterChip Deselected 1`] = `
 <button
   aria-label="I am an aria label"
-  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-200 text-gray-500"
+  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-200 text-gray-500 transition-opacity duration-75 ease-in-out opacity-50"
   onClick={[Function]}
   type="button"
 >

--- a/test/components/FilterChip/__snapshots__/FilterChip.stories.storyshot
+++ b/test/components/FilterChip/__snapshots__/FilterChip.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots UI Elements/FilterChip Default 1`] = `
 <button
   aria-label="I am an aria label"
-  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-400 text-gray-900 transition-opacity duration-75 ease-in-out opacity-100"
+  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-40 transition-opacity duration-75 ease-in-out opacity-100 disabled:opacity-100 disabled:cursor-not-allowed"
   onClick={[Function]}
   type="button"
 >
@@ -16,7 +16,7 @@ exports[`Storyshots UI Elements/FilterChip Default 1`] = `
 exports[`Storyshots UI Elements/FilterChip Deselected 1`] = `
 <button
   aria-label="I am an aria label"
-  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-200 text-gray-500 transition-opacity duration-75 ease-in-out opacity-50"
+  className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white border-gray-200 transition-opacity duration-75 ease-in-out opacity-50 disabled:opacity-100 disabled:cursor-not-allowed"
   onClick={[Function]}
   type="button"
 >

--- a/test/components/LayerLegendBlock/__snapshots__/LayerLegendBlock.stories.storyshot
+++ b/test/components/LayerLegendBlock/__snapshots__/LayerLegendBlock.stories.storyshot
@@ -58,7 +58,8 @@ exports[`Storyshots UI Elements/LayerLegendBlock Default 1`] = `
     >
       <button
         aria-label="I am a title an oder auswählen"
-        className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white w-full border-gray-400 text-gray-900 transition-opacity duration-75 ease-in-out opacity-100"
+        className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white w-full border-gray-40 transition-opacity duration-75 ease-in-out opacity-100 disabled:opacity-100 disabled:cursor-not-allowed"
+        disabled={false}
         onClick={[Function]}
         type="button"
       />

--- a/test/components/LayerLegendBlock/__snapshots__/LayerLegendBlock.stories.storyshot
+++ b/test/components/LayerLegendBlock/__snapshots__/LayerLegendBlock.stories.storyshot
@@ -58,7 +58,7 @@ exports[`Storyshots UI Elements/LayerLegendBlock Default 1`] = `
     >
       <button
         aria-label="I am a title an oder auswählen"
-        className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white w-full border-gray-400 text-gray-900"
+        className="px-2 py-1 border rounded-md focus:rounded focus:ring-2 focus:ring-gray-800 focus:outline-none focus:ring-offset-2 focus:ring-offset-white w-full border-gray-400 text-gray-900 transition-opacity duration-75 ease-in-out opacity-100"
         onClick={[Function]}
         type="button"
       />

--- a/test/components/Warning/__snapshots__/Warning.stories.storyshot
+++ b/test/components/Warning/__snapshots__/Warning.stories.storyshot
@@ -2,7 +2,7 @@
 
 exports[`Storyshots UI Elements/Warning With Long Text Content 1`] = `
 <div
-  className="flex max-w-prose p-3 border border-[#ff7300] border-opacity-40 rounded"
+  className="flex max-w-prose p-3"
 >
   <div
     className="flex-grow-0 text-[#ff7300]"
@@ -23,7 +23,7 @@ exports[`Storyshots UI Elements/Warning With Long Text Content 1`] = `
     </svg>
   </div>
   <div
-    className="ml-2"
+    className="ml-2 text-left"
   >
     <p>
       A lot went wrong here. That's why there is a a long warning message. Very, very long message. A lot went wrong here. That's why there is a a long warning message. Very, very long message. A lot went wrong here. That's why there is a a long warning message. Very, very long message. A lot went wrong here. That's why there is a a long warning message. Very, very long message.
@@ -34,7 +34,7 @@ exports[`Storyshots UI Elements/Warning With Long Text Content 1`] = `
 
 exports[`Storyshots UI Elements/Warning With Short Text Content 1`] = `
 <div
-  className="flex max-w-prose p-3 border border-[#ff7300] border-opacity-40 rounded"
+  className="flex max-w-prose p-3"
 >
   <div
     className="flex-grow-0 text-[#ff7300]"
@@ -55,7 +55,7 @@ exports[`Storyshots UI Elements/Warning With Short Text Content 1`] = `
     </svg>
   </div>
   <div
-    className="ml-2"
+    className="ml-2 text-left"
   >
     <p>
       I am a short warning text.


### PR DESCRIPTION
This PR syncs the sidebar filters with their respective URL query parameters. This includes the layers:

- shadows
- wind
- temperature
- POIs

---

Additionally, the PR adds a hint for the turquoise colors if both wind and temperature are active. It also improves the appearance of the webp support note.

---

Fixes:
- the `InternalLink` now handles the query properly
- the `queryUtil` was extended to handle selections of single and no places at all
- the `MapPointLayer` is now able to hide _all_ of its points if desired