### PR TITLE
Replace incorrect tilesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # _Berliner Erfrischungskarte_
-> The _Berliner Erfrischungskarte_ (Berlin refreshment map) is an interactive map of Berlin that shows shadows, wind areas and temperature intensities across a typical summer day.
+> The [_Berliner Erfrischungskarte_](https://erfrischungskarte.odis-berlin.de) (Berlin refreshment map) is an interactive map of Berlin that shows shadows, cold wind areas and temperature intensities across a typical summer day.
 
 ## Context
 Climate change is causing increasingly hot, dry weather in many places. In recent years, Berlin has also experienced more hot days than ever before.
@@ -17,7 +17,7 @@ This website is a NextJS app configured with:
 - Testing with [Jest](https://jestjs.io/) and [`react-testing-library`](https://testing-library.com/docs/react-testing-library/intro)
 
 ## Data
-This repository contains the **frontend** code of the _Berliner Erfrischungskarte_ app. All the **data** is contained in another repository: [erfrischungskarte-daten](https://github.com/technologiestiftung/erfrischungskarte-daten)
+This repository contains the **frontend** code of the _Berliner Erfrischungskarte_ app. The **data** and the data processing scripts are contained in another repository: [erfrischungskarte-daten](https://github.com/technologiestiftung/erfrischungskarte-daten). There you can also find further information about the original data sources.
 
 ## Install and contribute
 

--- a/src/modules/RefreshmentMap/content.tsx
+++ b/src/modules/RefreshmentMap/content.tsx
@@ -54,10 +54,9 @@ export const HOURS: HourDataType = {
     shadeTilesetId: 'mapbox://technologiestiftung.6pkd1c22',
   },
   '11': {
-    // incomplete, needs to be replaced!
     displayName: '11 Uhr',
     vectorTilesetKey: '11Uhr',
-    shadeTilesetId: 'mapbox://technologiestiftung.cgvhefjx',
+    shadeTilesetId: 'mapbox://technologiestiftung.a7c0dvqi',
   },
   '12': {
     displayName: '12 Uhr',
@@ -87,7 +86,7 @@ export const HOURS: HourDataType = {
   '17': {
     displayName: '17 Uhr',
     vectorTilesetKey: '17Uhr',
-    shadeTilesetId: 'mapbox://technologiestiftung.9vqcrksk',
+    shadeTilesetId: 'mapbox://technologiestiftung.77hu0gps',
   },
   '18': {
     displayName: '18 Uhr',

--- a/src/modules/RefreshmentMap/content.tsx
+++ b/src/modules/RefreshmentMap/content.tsx
@@ -119,8 +119,8 @@ export const WIND_DATA: Pick<
 > = {
   id: 'wind-data',
   tileset: {
-    url: 'mapbox://technologiestiftung.9s5puknr',
-    layerName: 'wind_data-221dgh',
+    url: 'mapbox://technologiestiftung.1hrk87mv',
+    layerName: 'wind_data-dgvmuc',
   },
   fillColorMap: new Map([
     // Note: the mapping here is different than the one for the temperature data.
@@ -138,8 +138,8 @@ export const TEMPERATURE_DATA: Pick<
 > = {
   id: 'temperature-data',
   tileset: {
-    url: 'mapbox://technologiestiftung.1ejpa7pd',
-    layerName: 'temperature_data-11wkut',
+    url: 'mapbox://technologiestiftung.4e9mfohk',
+    layerName: 'temperature_data-5k7yue',
   },
   fillColorMap: new Map([
     [1, colors['layer-blue'][400]],


### PR DESCRIPTION
@evelynebrie noticed that there was an error in the wind and temperature data with missing values. This has been fixed and the data re-uploaded to Mapbox. These commits integrate the new tilesets. In addition, new tilesets were integrated for 2 shadow layers, as the shadows were missing for certain areas of Berlin. I have also made minimal changes to the readme.