### PR TITLE
fix(Filters): display color blend note when no query provided

### DIFF
--- a/pages/filters.tsx
+++ b/pages/filters.tsx
@@ -45,6 +45,11 @@ export const Filters: FC<{
     wind: windLegendContent,
   } = LAYER_LEGEND_ITEMS
 
+  const windAndTemperatureFiltersAreActivated =
+    (!Object.keys(mappedQuery).includes('showWind') &&
+      !Object.keys(mappedQuery).includes('showTemperature')) ||
+    (mappedQuery.showWind === true && mappedQuery.showTemperature === true)
+
   return (
     <div className="grid grid-cols-1">
       <section
@@ -224,7 +229,7 @@ export const Filters: FC<{
             />
           </div>
         )}
-        {mappedQuery.showWind && mappedQuery.showTemperature && (
+        {windAndTemperatureFiltersAreActivated && (
           <p
             className={classNames(
               'text-xs',

--- a/test/pages/filters.test.tsx
+++ b/test/pages/filters.test.tsx
@@ -4,11 +4,10 @@ import * as nextRouter from 'next/router'
 import { Filters } from '../../pages/filters'
 import * as hasWebPSupport from '@lib/hooks/useHasWebPSupport'
 
+const useRouter = jest.fn()
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-nextRouter.useRouter = jest.fn().mockReturnValue({
-  query: {},
-})
+nextRouter.useRouter = useRouter
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -19,7 +18,6 @@ jest.mock('next/image', () => ({ src, alt }) => {
 })
 
 const useHasWebPSupport = jest.fn()
-
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 hasWebPSupport.useHasWebPSupport = useHasWebPSupport
@@ -27,6 +25,9 @@ hasWebPSupport.useHasWebPSupport = useHasWebPSupport
 describe('Filters page', () => {
   it('renders without crashing', () => {
     useHasWebPSupport.mockReturnValue(true)
+    useRouter.mockReturnValue({
+      query: {},
+    })
 
     render(<Filters query={{}} />)
 
@@ -36,10 +37,54 @@ describe('Filters page', () => {
 
   it('displays a note if webp is not supported', () => {
     useHasWebPSupport.mockReturnValue(false)
+    useRouter.mockReturnValue({
+      query: {},
+    })
 
     render(<Filters query={{}} />)
 
     const supportNote = screen.getByText(/Leider können die Schatten/i)
     expect(supportNote).toBeInTheDocument()
+  })
+
+  it('explains wind/temperature color blend when no query provided (both filters active by default)', () => {
+    useHasWebPSupport.mockReturnValue(true)
+    useRouter.mockReturnValue({
+      query: {},
+    })
+
+    render(<Filters query={{}} />)
+
+    const turquoiseNote = screen.getByText(/Aufgepasst/i)
+    expect(turquoiseNote).toBeInTheDocument()
+  })
+
+  it('hides wind/temperature color blend note when one filter is false', () => {
+    useHasWebPSupport.mockReturnValue(true)
+    useRouter.mockReturnValue({
+      query: {
+        showWind: 'false',
+      },
+    })
+
+    render(<Filters query={{}} />)
+
+    const turquoiseNote = screen.queryByText(/Aufgepasst/i)
+    expect(turquoiseNote).not.toBeInTheDocument()
+  })
+
+  it('explains wind/temperature color blend when both filters are true in query', () => {
+    useHasWebPSupport.mockReturnValue(true)
+    useRouter.mockReturnValue({
+      query: {
+        showWind: 'true',
+        showTemperature: 'true',
+      },
+    })
+
+    render(<Filters query={{}} />)
+
+    const turquoiseNote = screen.getByText(/Aufgepasst/i)
+    expect(turquoiseNote).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
So, I introduced a flaw in #36: the note for the turquoise colors (when both wind and temperature are active) was not displayed by default. This should have been the case since not explicitly setting the filters to `false` in the query results in the filters and layers being active.

In this PR, the bug is fixed and some more testing added to hopefully prevent such a misbehavior in the future.