### PR TITLE
fix(queryUtil): add missing return statement

### DIFF
--- a/src/lib/utils/queryUtil/index.ts
+++ b/src/lib/utils/queryUtil/index.ts
@@ -35,7 +35,7 @@ const parseNumbersArray = (
   if (typeof val !== 'string') return null
   try {
     const parsedJson = JSON.parse(val) as unknown
-    if (isNumber(parsedJson)) [parsedJson] as number[]
+    if (isNumber(parsedJson)) return [parsedJson] as number[]
     if (!Array.isArray(parsedJson)) return null
     return parsedJson.map(parseSingleNumber).filter(Boolean) as number[]
   } catch (err) {

--- a/src/lib/utils/queryUtil/queryUtil.test.ts
+++ b/src/lib/utils/queryUtil/queryUtil.test.ts
@@ -15,7 +15,7 @@ describe('mapRawQueryToState', () => {
       latitude: `${testLat}`,
       longitude: `${testLng}`,
       zoom: `${testZoom}`,
-      places: `[${testPlaces.join(',')}]`,
+      places: testPlaces.map((id) => id.toString()),
       showShadows: testShowShadows.toString(),
       showTemperature: testShowTemperature.toString(),
       showWind: testShowWind.toString(),
@@ -63,7 +63,7 @@ describe('mapRawQueryToState', () => {
   test('should return an array of numbers for places', () => {
     expect(
       mapRawQueryToState({
-        places: '[1,2,3,4]',
+        places: ['1', '2', '3', '4'],
       }).places
     ).toMatchObject([1, 2, 3, 4])
   })
@@ -78,7 +78,7 @@ describe('mapRawQueryToState', () => {
   test('should filter out places that are not valid', () => {
     expect(
       mapRawQueryToState({
-        places: '[1,null,"aa"]',
+        places: ['1', 'null', 'aa'],
       }).places
     ).toMatchObject([1])
   })


### PR DESCRIPTION
This PR adds a missing return statement to the `queryUtil`'s that was responsible for the POI filters nor behaving correctly.

---

Tests were also updated.