### PR TITLE
Feat ERF-95 - "Erkunden" link on desktop should redirect to "/filters"

### DIFF
--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -34,7 +34,7 @@ export const SplashScreen: FC = () => {
         </p>
         <div className="mt-4 md:mt-16 flex flex-wrap place-items-start">
           <InternalLink
-            href={hasMobileSize ? '/filters' : '/map'}
+            href={hasMobileSize ? '/map' : '/filters'}
             className={classNames(
               'md:px-4 mr-2 mb-2 cursor-pointer px-2.5 py-1 rounded-lg border-2',
               'bg-layer-turquoise-300 border-layer-turquoise-300',

--- a/src/components/SplashScreen/index.tsx
+++ b/src/components/SplashScreen/index.tsx
@@ -2,8 +2,11 @@ import React, { FC } from 'react'
 import { InternalLink } from '@components/InternalLink'
 import { CrossIcon, OpenDataIcon, SunIcon } from '@components/Icons'
 import classNames from 'classnames'
+import { useHasMobileSize } from '@lib/hooks/useHasMobileSize'
 
 export const SplashScreen: FC = () => {
+  const hasMobileSize = useHasMobileSize()
+
   return (
     <div className="fixed z-10 inset-0 flex flex-col justify-center">
       <InternalLink href="/map" className="fixed inset-0" />
@@ -31,7 +34,7 @@ export const SplashScreen: FC = () => {
         </p>
         <div className="mt-4 md:mt-16 flex flex-wrap place-items-start">
           <InternalLink
-            href="/map"
+            href={hasMobileSize ? '/filters' : '/map'}
             className={classNames(
               'md:px-4 mr-2 mb-2 cursor-pointer px-2.5 py-1 rounded-lg border-2',
               'bg-layer-turquoise-300 border-layer-turquoise-300',

--- a/test/components/SplashScreen/__snapshots__/SplashScreen.stories.storyshot
+++ b/test/components/SplashScreen/__snapshots__/SplashScreen.stories.storyshot
@@ -98,7 +98,7 @@ exports[`Storyshots Content/SplashScreen Default 1`] = `
     >
       <a
         className="md:px-4 mr-2 mb-2 cursor-pointer px-2.5 py-1 rounded-lg border-2 bg-layer-turquoise-300 border-layer-turquoise-300 hover:bg-layer-turquoise-400 hover:border-layer-turquoise-400 text-white transition-colors inline-block flex-grow sm:flex-grow-0 text-center w-full sm:w-auto"
-        href="/map"
+        href="/filters"
         onClick={[Function]}
         onMouseEnter={[Function]}
       >


### PR DESCRIPTION
This PR ensures that on desktop, the "Erkunden" link in the splash screen leads to the filters page