### PR TITLE
fix(ERF-104): use working Google Maps link format

### DIFF
--- a/src/components/SharingOverlay/index.tsx
+++ b/src/components/SharingOverlay/index.tsx
@@ -1,6 +1,7 @@
 import { CrossIcon, SharingIcon } from '@components/Icons'
 import { useCopyToClipboard } from '@lib/hooks/useCopyToClipboard'
 import { mapRawQueryToState } from '@lib/utils/queryUtil'
+import { MAP_CONFIG } from '@modules/RefreshmentMap'
 import classNames from 'classnames'
 import { useRouter } from 'next/router'
 import { FC, ReactNode, useState } from 'react'
@@ -14,10 +15,14 @@ interface SharingOptionPropType {
 
 const getGoogleMapsLinkByQuery = (
   query: ReturnType<typeof mapRawQueryToState>
-): string =>
-  `https://www.google.com/maps/place/${query.latitude || ''},${
-    query.longitude || ''
-  },${query.zoom || ''}z`
+): string => {
+  const latLonString = `${query.latitude || MAP_CONFIG.defaultLatitude},${
+    query.longitude || MAP_CONFIG.defaultLongitude
+  }`
+  return `https://maps.google.com/?q=${latLonString}&ll=${latLonString}&z=${
+    query.zoom || MAP_CONFIG.defaultZoom
+  }`
+}
 
 export const SharingOption: FC<SharingOptionPropType> = ({
   title,

--- a/src/modules/RefreshmentMap/index.tsx
+++ b/src/modules/RefreshmentMap/index.tsx
@@ -50,7 +50,7 @@ interface CustomMapEventType extends MapEvent {
   features: MapFeatureType[]
 }
 
-const MAP_CONFIG = {
+export const MAP_CONFIG = {
   minZoom: 11.5,
   maxZoom: 17,
   defaultZoom: 14,


### PR DESCRIPTION
This PR fixes the Google Maps link that was not bringing people to the location/zoom that they were when on _Erfrischungskarte_. It follows a link formatting suggestion from [here](https://stackoverflow.com/questions/32806084/google-map-zoom-parameter-in-url-not-working).

Note (from the StackOverflow link): Apparently there is no official documentation for how to format these strings, plus the allowed formats change over time.